### PR TITLE
Enable node actions through workflow context

### DIFF
--- a/components/node-quick-actions.tsx
+++ b/components/node-quick-actions.tsx
@@ -30,7 +30,7 @@ interface NodeQuickActionsProps {
  * and a dropdown menu for additional options.
  */
 export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverChange }: NodeQuickActionsProps) {
-  const { removeNode, duplicateNode } = useWorkflow()
+  const { removeNode, duplicateNode, executeNode, toggleNodeDisabled } = useWorkflow()
 
   // Handle mouse enter event
   const handleMouseEnter = useCallback(() => {
@@ -45,29 +45,21 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
   const handleExecuteClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Execute node", nodeId)
-      // TODO: Implement actual node execution logic
-      // For now, just show a toast notification
-      if (typeof window !== 'undefined') {
-        // Simple notification for now
-        alert(`Executing node ${nodeId}`)
+      if (nodeId) {
+        executeNode(nodeId)
       }
     },
-    [nodeId],
+    [nodeId, executeNode],
   )
 
   const handleToggleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Toggle node active state", nodeId)
-      // TODO: Implement actual node toggle logic
-      // For now, just show a toast notification
-      if (typeof window !== 'undefined') {
-        // Simple notification for now
-        alert(`Toggling active state for node ${nodeId}`)
+      if (nodeId) {
+        toggleNodeDisabled(nodeId)
       }
     },
-    [nodeId],
+    [nodeId, toggleNodeDisabled],
   )
 
   const handleDeleteClick = useCallback(

--- a/context/workflow-context.tsx
+++ b/context/workflow-context.tsx
@@ -166,6 +166,33 @@ export function WorkflowProvider({ children }: { children: React.ReactNode }) {
     [nodes],
   )
 
+  const toggleNodeDisabled = useCallback((nodeId: string) => {
+    setNodes((prevNodes) =>
+      prevNodes.map((node) =>
+        node.id === nodeId ? { ...node, disabled: !node.disabled } : node,
+      ),
+    )
+  }, [])
+
+  const executeNode = useCallback(
+    async (nodeId: string) => {
+      const node = nodes.find((n) => n.id === nodeId)
+      if (!node) return
+
+      const code = node.data?.code
+      if (!code) return
+
+      try {
+        // eslint-disable-next-line no-new-func
+        const fn = new Function('input', code)
+        await fn(node.data?.input)
+      } catch (error) {
+        console.error('Error executing node:', error)
+      }
+    },
+    [nodes],
+  )
+
   const lockNode = useCallback((nodeId: string) => {
     setNodes((prevNodes) => prevNodes.map((node) => (node.id === nodeId ? { ...node, locked: true } : node)))
   }, [])
@@ -379,6 +406,8 @@ export function WorkflowProvider({ children }: { children: React.ReactNode }) {
       duplicateNode,
       lockNode,
       unlockNode,
+      toggleNodeDisabled,
+      executeNode,
       alignNodes,
       addConnection,
       removeConnection,
@@ -420,6 +449,8 @@ export function WorkflowProvider({ children }: { children: React.ReactNode }) {
       duplicateNode,
       lockNode,
       unlockNode,
+      toggleNodeDisabled,
+      executeNode,
       alignNodes,
       addConnection,
       removeConnection,


### PR DESCRIPTION
## Summary
- hook up `executeNode` and `toggleNodeDisabled` via the workflow context
- connect NodeQuickActions to use these workflow actions

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68479ca6b4d8832bb6909c83f385f840