### PR TITLE
Create .env.local automatically

### DIFF
--- a/README_FRONTEND.md
+++ b/README_FRONTEND.md
@@ -48,6 +48,8 @@ npm install --legacy-peer-deps
 ```bash
 # Método 1: Script automático
 ./start_frontend.sh
+# O script cria automaticamente o arquivo `.env.local` com valores
+padrão caso ele não exista
 
 # Método 2: Manual
 npm run dev

--- a/start_frontend.sh
+++ b/start_frontend.sh
@@ -5,10 +5,21 @@ echo "🌐 INICIANDO FRONTEND JOÃO CASTANHEIRA"
 echo "====================================="
 
 # Verificar se .env.local existe
-if [ ! -f .env.local ]; then
-    echo "❌ Arquivo .env.local não encontrado!"
-    echo "Execute o script setup_env.py primeiro"
-    exit 1
+if [ ! -f ".env.local" ]; then
+    echo ""
+    echo "⚙️  Configurando variáveis de ambiente..."
+    if [ -f ".env.example" ]; then
+        cp .env.example .env.local
+        echo "   ✅ Arquivo .env.local criado a partir do .env.example"
+    else
+        echo "   ⚠️  Arquivo .env.example não encontrado, criando .env.local básico"
+        cat > .env.local << EOF
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000
+NEXT_PUBLIC_APP_ENV=development
+EOF
+    fi
+    echo "   📝 Configure as variáveis em .env.local se necessário"
 fi
 
 # Verificar se node_modules existe
@@ -34,4 +45,3 @@ rm -rf .next
 # Iniciar servidor de desenvolvimento
 echo "🚀 Iniciando servidor Next.js..."
 npm run dev
-


### PR DESCRIPTION
## Summary
- generate `.env.local` in `start_frontend.sh` if missing
- note automatic `.env.local` creation in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68479cb8c97c832b93fd346dd35c841f