### PR TITLE
Add disabled state handling to workflow nodes

### DIFF
--- a/components/node-quick-actions.tsx
+++ b/components/node-quick-actions.tsx
@@ -20,6 +20,8 @@ interface NodeQuickActionsProps {
   nodeId?: string
   /** Callback for hover state changes */
   onHoverChange?: (hovered: boolean) => void
+  /** Whether the node is disabled */
+  disabled?: boolean
 }
 
 /**
@@ -29,7 +31,7 @@ interface NodeQuickActionsProps {
  * Includes buttons for common operations like execute, toggle active state, delete,
  * and a dropdown menu for additional options.
  */
-export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverChange }: NodeQuickActionsProps) {
+export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverChange, disabled = false }: NodeQuickActionsProps) {
   const { removeNode, duplicateNode } = useWorkflow()
 
   // Handle mouse enter event
@@ -162,7 +164,7 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
               <div className="ml-auto text-xs text-muted-foreground">F2</div>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleToggleClick}>
-              Deactivate
+              {disabled ? "Activate" : "Deactivate"}
               <div className="ml-auto text-xs text-muted-foreground">D</div>
             </DropdownMenuItem>
             <DropdownMenuItem>

--- a/components/workflow-node.tsx
+++ b/components/workflow-node.tsx
@@ -151,6 +151,7 @@ function WorkflowNodeComponent({
             nodeWidth={nodeWidth}
             nodeId={node.id}
             onHoverChange={handleActionsHoverChange}
+            disabled={node.disabled}
           />
         </div>
       )}
@@ -160,6 +161,7 @@ function WorkflowNodeComponent({
         className={cn(
           "relative rounded-md border shadow-sm bg-white cursor-move pointer-events-auto flex items-center justify-center",
           isSelected ? "ring-2 ring-primary shadow-md" : showQuickActions ? "ring-1 ring-primary/40 shadow-sm" : "",
+          node.disabled && "opacity-50"
         )}
         style={{
           width: nodeWidth,
@@ -246,7 +248,13 @@ function WorkflowNodeComponent({
       </div>
 
       {/* Node label - always shown below the node */}
-      <div className="mt-2 text-sm font-medium text-center text-foreground/80 truncate max-w-full" title={node.name}>
+      <div
+        className={cn(
+          "mt-2 text-sm font-medium text-center text-foreground/80 truncate max-w-full",
+          node.disabled && "opacity-50"
+        )}
+        title={node.name}
+      >
         {node.name}
       </div>
     </div>

--- a/components/workflow-node/index.tsx
+++ b/components/workflow-node/index.tsx
@@ -224,7 +224,12 @@ function WorkflowNodeComponent({
       {/* Ações rápidas - visíveis quando hover */}
       {showQuickActions && (
         <div className="node-quick-actions">
-          <NodeQuickActions onEditClick={onDoubleClick} nodeWidth={nodeWidth} nodeId={node.id} />
+          <NodeQuickActions
+            onEditClick={onDoubleClick}
+            nodeWidth={nodeWidth}
+            nodeId={node.id}
+            disabled={node.disabled}
+          />
         </div>
       )}
 
@@ -233,6 +238,7 @@ function WorkflowNodeComponent({
         className={cn(
           "relative rounded-md border shadow-sm bg-white cursor-move pointer-events-auto flex items-center justify-center transition-all duration-150",
           isSelected ? "ring-2 ring-primary shadow-md" : isHovered ? "ring-1 ring-primary/40 shadow-sm" : "",
+          node.disabled && "opacity-50"
         )}
         style={{
           width: nodeWidth,
@@ -260,7 +266,13 @@ function WorkflowNodeComponent({
       </div>
 
       {/* Rótulo do nó - sempre mostrado abaixo do nó */}
-      <div className="mt-2 text-sm font-medium text-center text-foreground/80 truncate max-w-full" title={node.name}>
+      <div
+        className={cn(
+          "mt-2 text-sm font-medium text-center text-foreground/80 truncate max-w-full",
+          node.disabled && "opacity-50"
+        )}
+        title={node.name}
+      >
         {node.name}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- support toggling disabled state in `NodeQuickActions`
- show disabled state in dropdown menu
- forward disabled flag from `WorkflowNode`
- visually indicate disabled nodes

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom'...)*
- `npm run lint` *(interactive prompt prevents running)*

------
https://chatgpt.com/codex/tasks/task_b_6847a1a58600832b875923cd6c9ec815