### PR TITLE
Add NodeQuickActions tests

### DIFF
--- a/components/node-quick-actions.tsx
+++ b/components/node-quick-actions.tsx
@@ -30,7 +30,8 @@ interface NodeQuickActionsProps {
  * and a dropdown menu for additional options.
  */
 export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverChange }: NodeQuickActionsProps) {
-  const { removeNode, duplicateNode } = useWorkflow()
+  const { removeNode, duplicateNode, executeNode, toggleNodeDisabled } =
+    useWorkflow()
 
   // Handle mouse enter event
   const handleMouseEnter = useCallback(() => {
@@ -45,29 +46,21 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
   const handleExecuteClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Execute node", nodeId)
-      // TODO: Implement actual node execution logic
-      // For now, just show a toast notification
-      if (typeof window !== 'undefined') {
-        // Simple notification for now
-        alert(`Executing node ${nodeId}`)
+      if (nodeId) {
+        executeNode(nodeId)
       }
     },
-    [nodeId],
+    [nodeId, executeNode],
   )
 
   const handleToggleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Toggle node active state", nodeId)
-      // TODO: Implement actual node toggle logic
-      // For now, just show a toast notification
-      if (typeof window !== 'undefined') {
-        // Simple notification for now
-        alert(`Toggling active state for node ${nodeId}`)
+      if (nodeId) {
+        toggleNodeDisabled(nodeId)
       }
     },
-    [nodeId],
+    [nodeId, toggleNodeDisabled],
   )
 
   const handleDeleteClick = useCallback(

--- a/tests/unit/node-quick-actions.test.tsx
+++ b/tests/unit/node-quick-actions.test.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NodeQuickActions } from '@/components/node-quick-actions';
+
+// Mock useWorkflow hook
+const mockExecuteNode = jest.fn();
+let nodeDisabled = false;
+const mockToggleNodeDisabled = jest.fn(() => {
+  nodeDisabled = !nodeDisabled;
+});
+const mockRemoveNode = jest.fn();
+const mockDuplicateNode = jest.fn();
+
+jest.mock('@/context/workflow-context', () => ({
+  useWorkflow: () => ({
+    removeNode: mockRemoveNode,
+    duplicateNode: mockDuplicateNode,
+    executeNode: mockExecuteNode,
+    toggleNodeDisabled: mockToggleNodeDisabled,
+  }),
+}));
+
+describe('NodeQuickActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nodeDisabled = false;
+  });
+
+  it('calls executeNode with the node id when execute is clicked', () => {
+    render(
+      <NodeQuickActions onEditClick={() => {}} nodeWidth={70} nodeId="node-1" />
+    );
+
+    const executeButton = screen.getByRole('button', { name: /execute node/i });
+    fireEvent.click(executeButton);
+
+    expect(mockExecuteNode).toHaveBeenCalledWith('node-1');
+  });
+
+  it('toggles node disabled state when toggle is clicked', () => {
+    render(
+      <NodeQuickActions onEditClick={() => {}} nodeWidth={70} nodeId="node-1" />
+    );
+
+    const toggleButton = screen.getByRole('button', { name: /toggle active state/i });
+    expect(nodeDisabled).toBe(false);
+    fireEvent.click(toggleButton);
+    expect(mockToggleNodeDisabled).toHaveBeenCalledWith('node-1');
+    expect(nodeDisabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- invoke workflow functions in NodeQuickActions
- add tests for execute and toggle actions

## Testing
- `npm test --silent` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_b_6847a1a8af08832b936c1d064adde04a