### PR TITLE
Refactor node execution logic

### DIFF
--- a/services/node-execution-service.ts
+++ b/services/node-execution-service.ts
@@ -1,0 +1,72 @@
+export async function executeCodeSafely(
+  code: string,
+  input: any,
+  captureConsole: (message: string) => void,
+  timeoutMs: number,
+  useSandbox: boolean,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Execution timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    try {
+      const safeConsole = {
+        log: (...args: any[]) => {
+          const message = args
+            .map((arg) => {
+              if (typeof arg === "object") {
+                try {
+                  return JSON.stringify(arg, null, 2);
+                } catch {
+                  return String(arg);
+                }
+              }
+              return String(arg);
+            })
+            .join(" ");
+          captureConsole(message);
+          console.log(...args);
+        },
+        error: (...args: any[]) => {
+          const message = args.map((arg) => String(arg)).join(" ");
+          captureConsole(`ERROR: ${message}`);
+          console.error(...args);
+        },
+        warn: (...args: any[]) => {
+          const message = args.map((arg) => String(arg)).join(" ");
+          captureConsole(`WARNING: ${message}`);
+          console.warn(...args);
+        },
+        info: (...args: any[]) => {
+          const message = args.map((arg) => String(arg)).join(" ");
+          captureConsole(`INFO: ${message}`);
+          console.info(...args);
+        },
+      };
+
+      // eslint-disable-next-line no-new-func
+      const fn = new Function(
+        "input",
+        "console",
+        `
+        "use strict";
+        try {
+          ${code}
+          return input;
+        } catch (error) {
+          console.error("Execution error:", error.message);
+          throw error;
+        }
+      `,
+      );
+
+      const result = fn(input, safeConsole);
+      clearTimeout(timeoutId);
+      resolve(result);
+    } catch (error) {
+      clearTimeout(timeoutId);
+      reject(error);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- extract shared `executeCodeSafely` utility
- use shared execution utility in `useNodeExecution`
- add workflow context `executeNode` implementation

## Testing
- `npm test` *(fails: module factory jest.mock out-of-scope variable)*

------
https://chatgpt.com/codex/tasks/task_b_6847a1a462dc832b84bf45bf13c2e99f