### PR TITLE
Fix parameter options key

### DIFF
--- a/components/node-definition/parameters-editor.tsx
+++ b/components/node-definition/parameters-editor.tsx
@@ -332,7 +332,7 @@ export function ParametersEditor({ parameters, onChange }: ParametersEditorProps
                             </TableHeader>
                             <TableBody>
                               {parameterOptions.map((option, index) => (
-                                <TableRow key={index}>
+                                <TableRow key={option.value || index}>
                                   <TableCell>{option.label}</TableCell>
                                   <TableCell>{option.value}</TableCell>
                                   <TableCell>


### PR DESCRIPTION
## Summary
- use option value for stable keys in parameter options list

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*


------
https://chatgpt.com/codex/tasks/task_b_6847a2502fc4832ba0694355f3c70877