### PR TITLE
Replace console.log with logger

### DIFF
--- a/app/agentes/novo/page.tsx
+++ b/app/agentes/novo/page.tsx
@@ -10,6 +10,7 @@ import { AgentConnectionsTab } from "@/components/agents/agent-connections-tab"
 import { Button } from "@/components/ui/button"
 import { ArrowLeft, Save, X } from "lucide-react"
 import { Section } from "@/components/ui/section"
+import { logger } from "@/utils/logger"
 
 export default function NovoAgentePage() {
   const router = useRouter()
@@ -33,7 +34,7 @@ export default function NovoAgentePage() {
 
   const handleSave = () => {
     // Aqui seria implementada a lógica para salvar o agente
-    console.log("Salvando agente:", agent)
+    logger.log("Salvando agente:", agent)
     router.push("/agentes")
   }
 

--- a/app/canvas/page.tsx
+++ b/app/canvas/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { useNodeDefinitionIntegration } from '@/hooks/use-node-definition-integration';
 import { useInitializeDefaultNodes } from '@/app/node-creator/init';
 import { WorkflowCanvas } from '@/components/workflow-canvas';
+import { logger } from '@/utils/logger';
 import { 
   Plus, 
   Share, 
@@ -96,7 +97,7 @@ export default function CanvasPage() {
   // Handler para abrir a biblioteca de nodes
   const handleOpenNodeLibrary = useCallback(() => {
     // Implementação da abertura da biblioteca de nodes
-    console.log('Abrindo biblioteca de nodes');
+    logger.log('Abrindo biblioteca de nodes');
     // Aqui seria implementada a lógica para abrir a biblioteca de nodes
   }, []);
 

--- a/app/node-creator/init.ts
+++ b/app/node-creator/init.ts
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useNodeDefinitions } from '@/context/node-definition-context';
 import { manualTriggerNode } from '@/data/manual-trigger-node';
+import { logger } from '@/utils/logger';
 
 /**
  * Hook para inicializar nodes padrão no sistema
@@ -18,7 +19,7 @@ export function useInitializeDefaultNodes() {
     
     // Se não existir, adicionar ao contexto
     if (!manualTriggerExists) {
-      console.log('Adicionando node de trigger manual ao sistema');
+      logger.log('Adicionando node de trigger manual ao sistema');
       
       // Converter NodeTemplate para NodeDefinition
       const nodeDefinition = {

--- a/components/auth/login-page.tsx
+++ b/components/auth/login-page.tsx
@@ -16,6 +16,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Eye, EyeOff, Mail, Lock, Zap } from 'lucide-react'
+import { logger } from '@/utils/logger'
 import { cn } from '@/lib/utils'
 
 export const LoginPage: React.FC = () => {
@@ -305,7 +306,7 @@ export const LoginPage: React.FC = () => {
                     disabled={isLoading}
                     onClick={() => {
                       // TODO: Implementar recuperação de senha
-                      console.log('Recuperar senha')
+                      logger.log('Recuperar senha')
                     }}
                   >
                     Esqueceu sua senha?

--- a/components/chat/chat-history-sidebar.tsx
+++ b/components/chat/chat-history-sidebar.tsx
@@ -7,6 +7,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Search, X, Clock, Star, Trash, ChevronLeft, MoreHorizontal, Edit, Copy, Archive } from "lucide-react"
 import type { Conversation } from "@/types/chat"
 import { motion, AnimatePresence } from "framer-motion"
+import { logger } from "@/utils/logger"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -216,7 +217,7 @@ export function ChatHistorySidebar({
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       // Implementar editar título
-                                      console.log('Editar título:', conversation.id)
+                                      logger.log('Editar título:', conversation.id)
                                     }}
                                   >
                                     <Edit className="h-4 w-4 mr-2" />
@@ -226,7 +227,7 @@ export function ChatHistorySidebar({
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       // Implementar copiar link
-                                      console.log('Copiar link:', conversation.id)
+                                      logger.log('Copiar link:', conversation.id)
                                     }}
                                   >
                                     <Copy className="h-4 w-4 mr-2" />
@@ -236,7 +237,7 @@ export function ChatHistorySidebar({
                                     onClick={(e) => {
                                       e.stopPropagation()
                                       // Implementar arquivar
-                                      console.log('Arquivar:', conversation.id)
+                                      logger.log('Arquivar:', conversation.id)
                                     }}
                                   >
                                     <Archive className="h-4 w-4 mr-2" />

--- a/components/chat/chat-message/index.tsx
+++ b/components/chat/chat-message/index.tsx
@@ -10,6 +10,7 @@
 import React from "react"
 import { Message } from "@/types/chat"
 import { User, Bot } from "lucide-react"
+import { logger } from "@/utils/logger"
 
 /**
  * Componente para mensagens do usuário
@@ -68,7 +69,7 @@ export function MessageActions({ message }: { message: Message }) {
     navigator.clipboard.writeText(message.content)
       .then(() => {
         // Poderia mostrar uma notificação de sucesso aqui
-        console.log("Conteúdo copiado para a área de transferência")
+        logger.log("Conteúdo copiado para a área de transferência")
       })
       .catch(err => {
         console.error("Erro ao copiar conteúdo:", err)

--- a/components/chat/chat-message/message-actions.tsx
+++ b/components/chat/chat-message/message-actions.tsx
@@ -6,6 +6,7 @@ import { Copy, ThumbsUp, ThumbsDown, MoreVertical, Repeat, CheckCircle } from "l
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { logger } from "@/utils/logger"
 
 interface MessageActionsProps {
   message: Message
@@ -26,7 +27,7 @@ export function MessageActions({ message }: MessageActionsProps) {
 
   const regenerateResponse = () => {
     // Implementação simplificada
-    console.log('Regenerar resposta')
+    logger.log('Regenerar resposta')
   }
 
   return (

--- a/components/chat/component-reference-message.tsx
+++ b/components/chat/component-reference-message.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import ComponentReference from "../component-selector/component-reference"
+import { logger } from "@/utils/logger"
 
 interface ComponentReferenceMessageProps {
   componentData: {
@@ -33,7 +34,7 @@ export default function ComponentReferenceMessage({ componentData }: ComponentRe
       onSelect={() => {
         // Aqui poderia ativar o seletor de componentes e focar neste componente
         // Por enquanto, apenas mostra uma mensagem no console
-        console.log("Componente selecionado:", componentData.name)
+        logger.log("Componente selecionado:", componentData.name)
       }}
     />
   )

--- a/components/chat/feedback-context.tsx
+++ b/components/chat/feedback-context.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback } from 'react'
 import { Message } from '@/types/chat'
+import { logger } from '@/utils/logger'
 
 interface FeedbackContextType {
   messageFeedback: Record<string, MessageFeedback>
@@ -38,7 +39,7 @@ export function FeedbackProvider({ children }: { children: React.ReactNode }) {
     }))
     
     // Enviar feedback para análise (poderia ser uma API real)
-    console.log(`Feedback enviado para mensagem ${messageId}:`, feedback)
+    logger.log(`Feedback enviado para mensagem ${messageId}:`, feedback)
     
     // Armazenar localmente para análise futura
     try {

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -5,6 +5,7 @@ import type React from "react"
 import { useState, useEffect, useRef } from "react"
 import { Command } from "cmdk"
 import { Search, X } from "lucide-react"
+import { logger } from "@/utils/logger"
 
 // Extrair os itens de comando para um componente separado
 import { CommandItem } from "@/components/command/command-item"
@@ -60,7 +61,7 @@ export function CommandPalette({ onClose = () => {} }: CommandPaletteProps) {
 
   // Handle command selection
   const handleSelect = (id: string) => {
-    console.log(`Selected command: ${id}`)
+    logger.log(`Selected command: ${id}`)
     handleClose()
   }
 

--- a/components/node-editor/node-editor-three-panel.tsx
+++ b/components/node-editor/node-editor-three-panel.tsx
@@ -9,6 +9,7 @@ import { CodeEditor } from "./code-editor"
 import { DataViewer } from "./data-viewer"
 import { ConsoleOutput } from "./console-output"
 import { EmptyState } from "./empty-state"
+import { logger } from "@/utils/logger"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
@@ -117,7 +118,7 @@ export function NodeEditorThreePanel({
   // Handle execute previous nodes
   const handleExecutePrevious = () => {
     // This would be implemented based on workflow context
-    console.log("Execute previous nodes")
+    logger.log("Execute previous nodes")
   }
 
   // Handle set mock data

--- a/components/node-quick-actions.tsx
+++ b/components/node-quick-actions.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { useCallback } from "react"
 import { useWorkflow } from "@/context/workflow-context"
+import { logger } from "@/utils/logger"
 
 interface NodeQuickActionsProps {
   /** Handler for edit button click */
@@ -45,7 +46,7 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
   const handleExecuteClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Execute node", nodeId)
+      logger.log("Execute node", nodeId)
       // TODO: Implement actual node execution logic
       // For now, just show a toast notification
       if (typeof window !== 'undefined') {
@@ -59,7 +60,7 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
   const handleToggleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      console.log("Toggle node active state", nodeId)
+      logger.log("Toggle node active state", nodeId)
       // TODO: Implement actual node toggle logic
       // For now, just show a toast notification
       if (typeof window !== 'undefined') {

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { motion, AnimatePresence } from "framer-motion"
+import { logger } from "@/utils/logger"
 import { 
   ChevronLeft,
   ChevronRight,
@@ -260,7 +261,7 @@ export function Sidebar() {
   }
 
   // Para desktop, usar layout flexbox sem position fixed
-  console.log('Renderizando sidebar desktop');
+  logger.log('Renderizando sidebar desktop');
   return (
     <motion.nav
       className="h-full border-r border-border overflow-hidden shadow-md flex flex-col flex-shrink-0"

--- a/components/variables/auto-sync.tsx
+++ b/components/variables/auto-sync.tsx
@@ -9,6 +9,7 @@ import { useEffect, useCallback, useState } from 'react'
 import { useAuth } from '@/context/auth-context'
 import { useVariables } from '@/context'
 import { toast } from 'sonner'
+import { logger } from '@/utils/logger'
 
 /**
  * Interface para configurações de sincronização
@@ -52,7 +53,7 @@ export function useAutoSync(config: Partial<SyncConfig> = {}) {
       
       if (success) {
         setRetryCount(0)
-        console.log('Variáveis sincronizadas automaticamente')
+        logger.log('Variáveis sincronizadas automaticamente')
       } else {
         throw new Error('Falha na sincronização')
       }

--- a/components/workflow-editor.tsx
+++ b/components/workflow-editor.tsx
@@ -8,6 +8,7 @@ import { CommandPalette } from "@/components/command-palette"
 import { useWorkflow } from "@/context/workflow-context"
 import { useState, useCallback } from "react"
 import type { Position } from "@/types/workflow"
+import { logger } from "@/utils/logger"
 
 export function WorkflowEditor() {
   const { selectedNodeId } = useWorkflow()
@@ -43,7 +44,7 @@ export function WorkflowEditor() {
               onClose={handleCloseNodePanel}
               onAddNode={(type, data) => {
                 // Implementação da adição de nó
-                console.log("Adding node:", type, data)
+                logger.log("Adding node:", type, data)
                 handleCloseNodePanel()
               }}
             />

--- a/context/node-template-context.tsx
+++ b/context/node-template-context.tsx
@@ -12,6 +12,7 @@
 
 import type React from "react"
 import { createContext, useContext, useState, useEffect, useCallback } from "react"
+import { logger } from "@/utils/logger"
 import type { NodeTemplate } from "@/types/node-template"
 
 /**
@@ -127,7 +128,7 @@ export function NodeTemplateProvider({ children }: { children: React.ReactNode }
         return
       }
       // In a real app, you would apply the template to the workflow
-      console.log(`Applying template ${template.name}`)
+      logger.log(`Applying template ${template.name}`)
     },
     [templates],
   )

--- a/context/workflow-context.tsx
+++ b/context/workflow-context.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 import { createContext, useContext, useState, useCallback, useMemo } from "react"
+import { logger } from "@/utils/logger"
 import type { Node, Connection, Position } from "@/types/workflow"
 import { nanoid } from "nanoid"
 
@@ -354,7 +355,7 @@ export function WorkflowProvider({ children }: { children: React.ReactNode }) {
 
   const saveWorkflow = useCallback(() => {
     // Mock save function
-    console.log("Saving workflow:", { nodes, connections, workflowName })
+    logger.log("Saving workflow:", { nodes, connections, workflowName })
     alert("Workflow saved!")
   }, [nodes, connections, workflowName])
 

--- a/contexts/node-creator/shared-nodes-context.tsx
+++ b/contexts/node-creator/shared-nodes-context.tsx
@@ -5,6 +5,7 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { NodeTemplate } from './types';
 import { SharedNodesState, SharedNodesAction, WorkflowNodeDefinition } from './shared-nodes-types';
 import { convertToWorkflowFormat } from '@/lib/adapters/node-format-adapter';
+import { logger } from '@/utils/logger';
 
 // Estado inicial
 const initialState: SharedNodesState = {
@@ -103,7 +104,7 @@ export function SharedNodesProvider({ children }: { children: React.ReactNode })
 
   const syncNodesWithWorkflow = () => {
     // Implementação futura: sincronizar com API ou outro mecanismo
-    console.log('Syncing nodes with workflow...');
+    logger.log('Syncing nodes with workflow...');
   };
 
   return (

--- a/hooks/use-chat-message.tsx
+++ b/hooks/use-chat-message.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback } from 'react'
+import { logger } from '@/utils/logger'
 import { Message } from '@/types/chat'
 
 /**
@@ -22,7 +23,7 @@ export function useChatMessage(message?: Message) {
 
   const regenerateResponse = useCallback(() => {
     // Implementação simplificada
-    console.log('Regenerar resposta para:', message?.id)
+    logger.log('Regenerar resposta para:', message?.id)
   }, [message])
 
   return {

--- a/hooks/use-node-definition-integration.ts
+++ b/hooks/use-node-definition-integration.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useCallback } from 'react';
+import { logger } from '@/utils/logger';
 import { useSharedNodes } from '@/contexts/node-creator/shared-nodes-context';
 import { useNodeCreator } from '@/contexts/node-creator/node-creator-context';
 
@@ -24,7 +25,7 @@ export function useNodeDefinitionIntegration() {
     
     // Adicionar cada template publicado ao SharedNodes
     publishedTemplates.forEach(template => {
-      console.log('Sincronizando node publicado para o Canvas Principal:', template.name);
+      logger.log('Sincronizando node publicado para o Canvas Principal:', template.name);
       addNodeToWorkflow(template);
     });
   }, [nodeCreatorState.nodeTemplates, sharedNodesState.sharedNodes, addNodeToWorkflow]);
@@ -39,7 +40,7 @@ export function useNodeDefinitionIntegration() {
     const customNodes = sharedNodesState.sharedNodes.filter(node => node.isCustom);
     
     if (customNodes.length > 0) {
-      console.log('Nodes personalizados disponíveis para o Canvas Principal:', customNodes.length);
+      logger.log('Nodes personalizados disponíveis para o Canvas Principal:', customNodes.length);
     }
   }, [sharedNodesState.sharedNodes]);
 

--- a/hooks/use-node-execution.ts
+++ b/hooks/use-node-execution.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
+import { logger } from "@/utils/logger"
 import { useVariables } from "@/context/variable-context"
 import { replaceVariablesInCode, trackVariablesInCode } from "@/utils/variable-utils"
 import type { Node } from "@/types/workflow"
@@ -96,7 +97,7 @@ export function useNodeExecution({ node, timeout = 5000, useSandbox = true }: Us
                 })
                 .join(" ")
               captureConsole(message)
-              console.log(...args) // Also log to the real console
+              logger.log(...args)
             },
             error: (...args: any[]) => {
               const message = args.map((arg) => String(arg)).join(" ")

--- a/hooks/use-websocket.ts
+++ b/hooks/use-websocket.ts
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { logger } from '@/utils/logger';
 import { useAuth } from '@/context/auth-context';
 
 export interface WebSocketEvent {
@@ -95,7 +96,7 @@ export function useExecutionWebSocket(
       const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
-        console.log(`🔗 WebSocket conectado para execução ${executionId}`);
+        logger.log(`🔗 WebSocket conectado para execução ${executionId}`);
         setConnectionStatus('connected');
         setError(null);
         reconnectAttemptsRef.current = 0;
@@ -125,7 +126,7 @@ export function useExecutionWebSocket(
           
           // Processa tipos específicos de eventos
           if (data.event_type === 'subscription_confirmed') {
-            console.log('✅ Subscrição confirmada:', data.data);
+            logger.log('✅ Subscrição confirmada:', data.data);
           } else if (data.event_type === 'stats_response') {
             setStats(data.data as ExecutionStats);
           }
@@ -136,7 +137,7 @@ export function useExecutionWebSocket(
       };
 
       ws.onclose = (event) => {
-        console.log(`🔌 WebSocket desconectado (código: ${event.code})`);
+        logger.log(`🔌 WebSocket desconectado (código: ${event.code})`);
         setConnectionStatus('disconnected');
         
         // Limpa heartbeat
@@ -148,7 +149,7 @@ export function useExecutionWebSocket(
         // Tenta reconectar se habilitado
         if (autoReconnect && reconnectAttemptsRef.current < maxReconnectAttempts) {
           reconnectAttemptsRef.current++;
-          console.log(`🔄 Tentativa de reconexão ${reconnectAttemptsRef.current}/${maxReconnectAttempts}`);
+          logger.log(`🔄 Tentativa de reconexão ${reconnectAttemptsRef.current}/${maxReconnectAttempts}`);
           
           reconnectTimeoutRef.current = setTimeout(() => {
             connect();
@@ -278,7 +279,7 @@ export function useGlobalWebSocket(
       const ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {
-        console.log('🌐 WebSocket global conectado');
+        logger.log('🌐 WebSocket global conectado');
         setConnectionStatus('connected');
         setError(null);
         reconnectAttemptsRef.current = 0;
@@ -306,7 +307,7 @@ export function useGlobalWebSocket(
           setLastEvent(data);
           
           if (data.event_type === 'subscription_confirmed') {
-            console.log('✅ Subscrição global confirmada:', data.data);
+            logger.log('✅ Subscrição global confirmada:', data.data);
           } else if (data.event_type === 'global_stats_response') {
             setStats(data.data as GlobalStats);
           }
@@ -317,7 +318,7 @@ export function useGlobalWebSocket(
       };
 
       ws.onclose = (event) => {
-        console.log(`🔌 WebSocket global desconectado (código: ${event.code})`);
+        logger.log(`🔌 WebSocket global desconectado (código: ${event.code})`);
         setConnectionStatus('disconnected');
         
         if (heartbeatIntervalRef.current) {
@@ -327,7 +328,7 @@ export function useGlobalWebSocket(
         
         if (autoReconnect && reconnectAttemptsRef.current < maxReconnectAttempts) {
           reconnectAttemptsRef.current++;
-          console.log(`🔄 Tentativa de reconexão global ${reconnectAttemptsRef.current}/${maxReconnectAttempts}`);
+          logger.log(`🔄 Tentativa de reconexão global ${reconnectAttemptsRef.current}/${maxReconnectAttempts}`);
           
           reconnectTimeoutRef.current = setTimeout(() => {
             connect();

--- a/lib/analytics-hooks.tsx
+++ b/lib/analytics-hooks.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useContext, useEffect } from 'react'
+import { logger } from '@/utils/logger'
 
 /**
  * Hook para utilizar analytics no projeto
@@ -9,12 +10,12 @@ import { useCallback, useContext, useEffect } from 'react'
 export function useAnalytics() {
   // Implementação mínima para resolver os imports
   const trackEvent = useCallback((eventName: string, properties?: Record<string, any>) => {
-    console.log('Analytics event tracked:', eventName, properties)
+    logger.log('Analytics event tracked:', eventName, properties)
     // Em produção, aqui seria implementada a integração real com analytics
   }, [])
 
   const trackPageView = useCallback((pageName: string, properties?: Record<string, any>) => {
-    console.log('Page view tracked:', pageName, properties)
+    logger.log('Page view tracked:', pageName, properties)
     // Em produção, aqui seria implementada a integração real com analytics
   }, [])
 

--- a/lib/api/service.ts
+++ b/lib/api/service.ts
@@ -3,6 +3,7 @@
  */
 
 // Configuração base da API
+import { logger } from '@/utils/logger';
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
 const WS_BASE_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/ws';
 
@@ -557,7 +558,7 @@ export class WebSocketService {
         this.ws = new WebSocket(wsUrl);
 
         this.ws.onopen = () => {
-          console.log('WebSocket connected');
+          logger.log('WebSocket connected');
           this.reconnectAttempts = 0;
           this.startHeartbeat();
           resolve();
@@ -573,7 +574,7 @@ export class WebSocketService {
         };
 
         this.ws.onclose = () => {
-          console.log('WebSocket disconnected');
+          logger.log('WebSocket disconnected');
           this.stopHeartbeat();
           this.attemptReconnect(token);
         };
@@ -635,7 +636,7 @@ export class WebSocketService {
   private attemptReconnect(token: string): void {
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.reconnectAttempts++;
-      console.log(`Attempting to reconnect (${this.reconnectAttempts}/${this.maxReconnectAttempts})...`);
+      logger.log(`Attempting to reconnect (${this.reconnectAttempts}/${this.maxReconnectAttempts})...`);
       
       setTimeout(() => {
         this.connect(token).catch(() => {

--- a/lib/api_optimized.ts
+++ b/lib/api_optimized.ts
@@ -5,6 +5,7 @@
  */
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 import { config } from './config_optimized'
+import { logger } from '@/utils/logger'
 
 // Types
 export interface ApiResponse<T = any> {
@@ -61,7 +62,7 @@ class ApiService {
 
         // Log in development
         if (this.isDevelopment()) {
-          console.log(`🌐 API Request: ${config.method?.toUpperCase()} ${config.url}`)
+          logger.log(`🌐 API Request: ${config.method?.toUpperCase()} ${config.url}`)
         }
 
         return config
@@ -77,7 +78,7 @@ class ApiService {
       (response) => {
         // Log in development
         if (this.isDevelopment()) {
-          console.log(`✅ API Response: ${response.status} ${response.config.url}`)
+          logger.log(`✅ API Response: ${response.status} ${response.config.url}`)
         }
 
         return response

--- a/lib/config_optimized.ts
+++ b/lib/config_optimized.ts
@@ -3,6 +3,7 @@
  * Criado por José - O melhor Full Stack do mundo
  * Implementa todas as melhores práticas de configuração
  */
+import { logger } from '@/utils/logger'
 
 interface Config {
   // URLs
@@ -110,7 +111,7 @@ export const config = getConfig()
 
 // Validations
 if (config.isDevelopment) {
-  console.log('🔧 Configurações de desenvolvimento carregadas:', {
+  logger.log('🔧 Configurações de desenvolvimento carregadas:', {
     apiUrl: config.apiUrl,
     wsUrl: config.wsUrl,
     features: config.features,

--- a/lib/performance-optimizations.ts
+++ b/lib/performance-optimizations.ts
@@ -23,6 +23,7 @@ import { DashboardSidebar } from '@/components/dashboard/sidebar'
 import { RecentProjects } from '@/components/dashboard/recent-projects'
 import { ProjectStats } from '@/components/dashboard/project-stats'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
+import { logger } from '@/utils/logger'
 
 // Função para buscar dados do servidor
 async function getProjectData() {
@@ -331,11 +332,11 @@ export function StreamingChat() {
     // Opções para streaming
     onResponse: (response) => {
       // Você pode processar a resposta aqui
-      console.log('Streaming started', response)
+      logger.log('Streaming started', response)
     },
     onFinish: (message) => {
       // Chamado quando o streaming termina
-      console.log('Streaming finished', message)
+      logger.log('Streaming finished', message)
     },
   })
   
@@ -842,7 +843,7 @@ export async function POST(req: Request) {
       })
     } else {
       // Em desenvolvimento, apenas loga os eventos
-      console.log('[Analytics] Received events:', data.events.length)
+      logger.log('[Analytics] Received events:', data.events.length)
     }
     
     return NextResponse.json({ success: true })

--- a/lib/performance/monitor.ts
+++ b/lib/performance/monitor.ts
@@ -4,6 +4,7 @@
  * Sistema avançado de monitoramento de performance para detectar
  * gargalos, medir métricas e otimizar a aplicação em tempo real.
  */
+import { logger } from '@/utils/logger'
 
 interface PerformanceMetric {
   name: string
@@ -67,7 +68,7 @@ class PerformanceMonitor {
     this.startNetworkMonitoring()
     this.startUserInteractionMonitoring()
 
-    console.log('🚀 Performance Monitor iniciado')
+    logger.log('🚀 Performance Monitor iniciado')
   }
 
   /**
@@ -80,7 +81,7 @@ class PerformanceMonitor {
     this.observers.forEach(observer => observer.disconnect())
     this.observers = []
 
-    console.log('⏹️ Performance Monitor parado')
+    logger.log('⏹️ Performance Monitor parado')
   }
 
   /**
@@ -503,7 +504,7 @@ class PerformanceMonitor {
   clearMetrics(): void {
     this.metrics = []
     this.alerts = []
-    console.log('🧹 Métricas de performance limpas')
+    logger.log('🧹 Métricas de performance limpas')
   }
 }
 

--- a/lib/utils/connectivity.ts
+++ b/lib/utils/connectivity.ts
@@ -6,6 +6,7 @@
 import { apiService } from '../api'
 import { config } from '../config'
 import type { HealthResponse } from '../types/api'
+import { logger } from '@/utils/logger'
 
 export interface ConnectivityTestResult {
   success: boolean
@@ -231,7 +232,7 @@ export async function testApiEndpoints(): Promise<ConnectivityTestResult> {
  * Executa todos os testes de conectividade
  */
 export async function runConnectivityTests(): Promise<ConnectivityReport> {
-  console.log('🔍 Iniciando testes de conectividade...')
+  logger.log('🔍 Iniciando testes de conectividade...')
 
   const tests = {
     healthCheck: await testHealthCheck(),
@@ -264,15 +265,15 @@ export async function runConnectivityTests(): Promise<ConnectivityReport> {
   }
 
   // Log dos resultados
-  console.log('📊 Relatório de Conectividade:')
-  console.log(`   Status Geral: ${overall.toUpperCase()}`)
-  console.log(`   Testes Passaram: ${passed}/${total}`)
+  logger.log('📊 Relatório de Conectividade:')
+  logger.log(`   Status Geral: ${overall.toUpperCase()}`)
+  logger.log(`   Testes Passaram: ${passed}/${total}`)
   
   Object.entries(tests).forEach(([testName, result]) => {
     const icon = result.success ? '✅' : '❌'
-    console.log(`   ${icon} ${testName}: ${result.message}`)
+    logger.log(`   ${icon} ${testName}: ${result.message}`)
     if (!result.success && result.details) {
-      console.log(`      Detalhes:`, result.details)
+      logger.log(`      Detalhes:`, result.details)
     }
   })
 
@@ -283,7 +284,7 @@ export async function runConnectivityTests(): Promise<ConnectivityReport> {
  * Monitora conectividade continuamente
  */
 export function startConnectivityMonitoring(intervalMs = 30000): () => void {
-  console.log('🔄 Iniciando monitoramento de conectividade...')
+  logger.log('🔄 Iniciando monitoramento de conectividade...')
   
   const interval = setInterval(async () => {
     try {
@@ -299,7 +300,7 @@ export function startConnectivityMonitoring(intervalMs = 30000): () => void {
   // Retorna função para parar o monitoramento
   return () => {
     clearInterval(interval)
-    console.log('⏹️ Monitoramento de conectividade parado')
+    logger.log('⏹️ Monitoramento de conectividade parado')
   }
 }
 

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,22 @@
+export const logger = {
+  log: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.log(...args);
+    }
+  },
+  warn: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.warn(...args);
+    }
+  },
+  error: (...args: unknown[]): void => {
+    if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.error(...args);
+    }
+  },
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- use `logger.log` instead of `console.log`
- add a simple logger utility

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom' and jest.mock factory reference errors)*

------
https://chatgpt.com/codex/tasks/task_b_6847a3a0ae0c832ba86a73b21466e935