### PR TITLE
docs: mention logger utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,19 @@ npm run test:coverage
 npm run test:e2e
 ```
 
+## 📝 Logs de Debug
+
+Use o utilitário `utils/logger.ts` para registrar mensagens de depuração:
+
+```ts
+import { debug } from "@/utils/logger"
+
+debug("Valor da variável", foo)
+```
+
+Quando `NEXT_PUBLIC_APP_ENV` for `production`, essas mensagens são
+automaticamente ignoradas.
+
 ## 📈 Performance
 
 ### **Otimizações Implementadas**

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,22 @@
+/**
+ * Logging utilities used across the application.
+ *
+ * Use `debug()` for development-only logs. The messages will be
+ * suppressed automatically in production builds.
+ */
+
+/** Determines if the current environment is production */
+const IS_PRODUCTION = process.env.NEXT_PUBLIC_APP_ENV === 'production'
+
+/**
+ * Logs a debug message when not in production.
+ *
+ * @param args Values to log with console.debug
+ */
+export function debug(...args: unknown[]): void {
+  if (!IS_PRODUCTION) {
+    console.debug(...args)
+  }
+}
+
+export default { debug }


### PR DESCRIPTION
## Summary
- mention utils/logger.ts for debug logs
- centralize debug printing logic in utils/logger.ts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847a3a57fec832b97050d222906771e