### PR TITLE
Update Jest transform for JSX

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
     '^.+\\.(css|less|scss)$': 'identity-obj-proxy'
   },
   transform: {
-    '^.+\\.(ts|tsx)$': ['babel-jest', {
+    '^.+\\.(ts|tsx|js|jsx)$': ['babel-jest', {
       presets: [
         ['@babel/preset-env', { targets: { node: 'current' } }],
-        '@babel/preset-react',
+        ['@babel/preset-react', { runtime: 'automatic' }],
         '@babel/preset-typescript'
       ],
     }],


### PR DESCRIPTION
## Summary
- adjust jest config so babel-jest handles `js` and `jsx` files

## Testing
- `npm test --silent` *(fails: module factory of `jest.mock()` is not allowed to reference `document`)*

------
https://chatgpt.com/codex/tasks/task_b_6847b1202368832b847ba99f51b0aedc