### PR TITLE
Add transform ignore pattern for nanoid

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,9 @@ module.exports = {
       ],
     }],
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(nanoid)/)'
+  ],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/.next/'


### PR DESCRIPTION
## Summary
- add Jest transformIgnorePatterns to handle `nanoid`

## Testing
- `npm test` *(fails: TypeError: renderHook is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6847b87fa534832b86815a306268ee61