### PR TITLE
Add disabled check in NodeQuickActions

### DIFF
--- a/components/node-quick-actions.tsx
+++ b/components/node-quick-actions.tsx
@@ -30,7 +30,7 @@ interface NodeQuickActionsProps {
  * and a dropdown menu for additional options.
  */
 export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverChange }: NodeQuickActionsProps) {
-  const { removeNode, duplicateNode, executeNode, toggleNodeDisabled } = useWorkflow()
+  const { nodes, removeNode, duplicateNode, executeNode, toggleNodeDisabled } = useWorkflow()
 
   // Handle mouse enter event
   const handleMouseEnter = useCallback(() => {
@@ -46,10 +46,12 @@ export function NodeQuickActions({ onEditClick, nodeWidth = 70, nodeId, onHoverC
     (e: React.MouseEvent) => {
       e.stopPropagation()
       if (nodeId) {
+        const node = nodes.find((n) => n.id === nodeId)
+        if (node?.disabled) return
         executeNode(nodeId)
       }
     },
-    [nodeId, executeNode],
+    [nodeId, executeNode, nodes],
   )
 
   const handleToggleClick = useCallback(

--- a/context/workflow-context.tsx
+++ b/context/workflow-context.tsx
@@ -6,10 +6,10 @@ import type { Node, Connection, Position } from "@/types/workflow"
 import { nanoid } from "nanoid"
 
 // Inicialização sem nodes pré-existentes
-const initialNodes: Node[] = []
+const defaultNodes: Node[] = []
 
 // Inicialização sem conexões pré-existentes
-const initialConnections: Connection[] = []
+const defaultConnections: Connection[] = []
 
 /**
  * Interface for the workflow context
@@ -89,10 +89,18 @@ const WorkflowContext = createContext<WorkflowContextType | undefined>(undefined
 /**
  * Provider component for the workflow context
  */
-export function WorkflowProvider({ children }: { children: React.ReactNode }) {
+export function WorkflowProvider({
+  children,
+  initialNodes: initNodes = defaultNodes,
+  initialConnections: initConnections = defaultConnections,
+}: {
+  children: React.ReactNode
+  initialNodes?: Node[]
+  initialConnections?: Connection[]
+}) {
   // State for nodes and connections
-  const [nodes, setNodes] = useState<Node[]>(initialNodes)
-  const [connections, setConnections] = useState<Connection[]>(initialConnections)
+  const [nodes, setNodes] = useState<Node[]>(initNodes)
+  const [connections, setConnections] = useState<Connection[]>(initConnections)
 
   // State for selection
   const [selectedNode, setSelectedNode] = useState<Node | null>(null)

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,9 @@ module.exports = {
       ],
     }],
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(nanoid)/)'
+  ],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/.next/'
@@ -35,6 +38,7 @@ module.exports = {
     }
   },
   testMatch: [
-    '<rootDir>/tests/unit/**/*.test.(ts|tsx)'
+    '<rootDir>/tests/unit/**/*.test.(ts|tsx)',
+    '<rootDir>/tests/components/**/*.test.(ts|tsx)'
   ]
 }

--- a/tests/components/node-quick-actions.test.tsx
+++ b/tests/components/node-quick-actions.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+jest.unmock('@testing-library/react')
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WorkflowProvider } from '@/context/workflow-context'
+import { NodeQuickActions } from '@/components/node-quick-actions'
+
+const disabledNode = {
+  id: 'node-1',
+  type: 'action',
+  name: 'Test',
+  position: { x: 0, y: 0 },
+  inputs: [],
+  outputs: [],
+  disabled: true,
+}
+
+describe('NodeQuickActions', () => {
+  it('does not execute disabled node', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    render(
+      <WorkflowProvider initialNodes={[disabledNode]}>
+        <NodeQuickActions nodeId="node-1" nodeWidth={70} onEditClick={() => {}} />
+      </WorkflowProvider>
+    )
+
+    const executeButton = screen.getByRole('button', { name: 'Execute node' })
+    fireEvent.click(executeButton)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- avoid executing disabled nodes in NodeQuickActions
- allow passing initial nodes/connections to WorkflowProvider for tests
- adjust Jest config to transform nanoid and include component tests
- add NodeQuickActions test covering disabled execution scenario

## Testing
- `npm test -- node-quick-actions.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_6847b88d396c832b80f9c5fac59a77fd