### PR TITLE
Fix start_frontend.sh env handling

### DIFF
--- a/README_FRONTEND.md
+++ b/README_FRONTEND.md
@@ -48,8 +48,8 @@ npm install --legacy-peer-deps
 ```bash
 # Método 1: Script automático
 ./start_frontend.sh
-# O script cria automaticamente o arquivo `.env.local` com valores
-padrão caso ele não exista
+# Certifique-se de criar um arquivo `.env.local` ou `.env.production`
+# com suas configurações antes de executá-lo
 
 # Método 2: Manual
 npm run dev


### PR DESCRIPTION
## Summary
- check for `.env.local` or `.env.production` instead of creating default values
- source the chosen env file with auto-export
- make backend health check conditional on `NEXT_PUBLIC_API_URL`
- update README instructions for manual env file creation

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68484f282788832b9873e807aac771c1